### PR TITLE
fix various warnings

### DIFF
--- a/src/commands/dedupe_command.rs
+++ b/src/commands/dedupe_command.rs
@@ -624,7 +624,7 @@ fn perform_deduplication (
 			arguments,
 			& file_database);
 
-	let mut file_database =
+	let file_database =
 		file_database;
 
 	let mut file_deduper =

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,7 @@
 #![ allow (unused_parens) ]
 
-#[ macro_use ]
 extern crate clap;
 
-#[ macro_use ]
 extern crate output;
 
 extern crate btrfs;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::path::PathBuf;
 use std::rc::Rc;
 
@@ -10,16 +9,10 @@ pub type Hash = [u8; HASH_SIZE];
 
 pub const ZERO_HASH: Hash = [0u8; HASH_SIZE];
 
-pub type HashLists =
-	HashMap <Hash, Vec <PathBuf>>;
-
 #[ derive (Eq, Hash, PartialEq) ]
 pub struct CompareFileMetadata {
 	pub filename: Option <PathBuf>,
 	pub size: u64,
 }
-
-pub type CompareFileMetadataLists =
-	HashMap <CompareFileMetadata, Vec <PathBuf>>;
 
 // ex: noet ts=4 filetype=rust


### PR DESCRIPTION
    warning: unused `#[macro_use]` import
    --> src/main.rs:3:1
      |
    3 | #[ macro_use ]
      | ^^^^^^^^^^^^^^
      |
      = note: #[warn(unused_imports)] on by default

    warning: unused `#[macro_use]` import
    --> src/main.rs:6:1
      |
    6 | #[ macro_use ]
      | ^^^^^^^^^^^^^^

    warning: type alias is never used: `HashLists`
      --> src/types.rs:13:1
      |
    13 | / pub type HashLists =
    14 | |  HashMap <Hash, Vec <PathBuf>>;
      | |_______________________________^
      |
      = note: #[warn(dead_code)] on by default

    warning: type alias is never used: `CompareFileMetadataLists`
      --> src/types.rs:22:1
      |
    22 | / pub type CompareFileMetadataLists =
    23 | |  HashMap <CompareFileMetadata, Vec <PathBuf>>;
      | |______________________________________________^

    warning: variable does not need to be mutable
      --> src/commands/dedupe_command.rs:627:6
        |
    627 |  let mut file_database =
        |      ^^^^^^^^^^^^^^^^^
        |
        = note: #[warn(unused_mut)] on by default